### PR TITLE
removed Reg_u64b class, exists now in victron py libs

### DIFF
--- a/Kostal_SmartEnergyMeter.py
+++ b/Kostal_SmartEnergyMeter.py
@@ -8,12 +8,6 @@ from register import *
 
 log = logging.getLogger()
 
-class Reg_u64b(Reg_num):
-    def __init__(self, base, *args, **kwargs):
-        super(Reg_u64b, self).__init__(base, 4, *args, **kwargs)
-        self.coding = ('>Q', '>4H')
-        self.scale = float(self.scale)
-
 #nr_phases = [ 1, 3, 3 ]
 
 #phase_configs = [


### PR DESCRIPTION
Had an error due to the lack of the count attribute in the current implementation.
Reg_u64b is now implemented in Victron's dbus-modbus-client: https://github.com/victronenergy/dbus-modbus-client/blob/af178a63d33f6e392244b98a05a72362de8489f2/register.py#L107
